### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.6.0] - 2018-12-09
+
+### Fixed
+
+- [[#4]] Fix Symfony's 4.2 deprecations 
+
 ## [0.5.0] - 2018-03-30
+
 ### Added
 - Added `churn-php`
 - CodeClimate integration
@@ -86,3 +93,5 @@ from `PabloK\SupercacheBundle\Cache\CacheElement`
 - Changed Vagrant PHP OPcache folder to `/home/vagrant/tmp/php/opcache`
 - Cache Composer files in TravisCI builds
 - Added `.php_cs.dist` to files ignored on export
+
+[#4]: https://github.com/PabloKowalczyk/SupercacheBundle/pull/4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ looks like [abandoned](https://github.com/kiler129/SupercacheBundle/issues/16).
 |Branch|Build status|
 |---|---|
 |master|[![Build Status](https://travis-ci.org/PabloKowalczyk/SupercacheBundle.svg?branch=master)](https://travis-ci.org/PabloKowalczyk/SupercacheBundle)|
-|latest stable (0.5.0)|[![Build Status](https://travis-ci.org/PabloKowalczyk/SupercacheBundle.svg?branch=0.5.0)](https://travis-ci.org/PabloKowalczyk/SupercacheBundle)|
+|latest stable (0.6.0)|[![Build Status](https://travis-ci.org/PabloKowalczyk/SupercacheBundle.svg?branch=0.6.0)](https://travis-ci.org/PabloKowalczyk/SupercacheBundle)|
 
 # Supercache Bundle
 Static pages caching for Symfony Framework.


### PR DESCRIPTION
PRs:
- Use Docker instead of Vagrant for development environment #2
- Update dev tools #3
- Remove Symfony 4.2 deprecations #4